### PR TITLE
Get edtf-validate from GitHub so we get the latest version.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-django~=1.11.15
-edtf-validate>=1.0.0
+django~=1.11.18
+git+https://github.com/unt-libraries/edtf-validate.git@master#egg=edtf-validate


### PR DESCRIPTION
ping @ldko, @madhulika95b, this is ready for review. Just bumps the django patch version and more importantly starts getting edtf-validate directly from GitHub so we always get the latest version on master.