### PR TITLE
Upgrade to Django4

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python: ['3.6', '3.7', '3.8', '3.9']
+        python: ['3.8', '3.9', '3.10']
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
           python-version: ${{ matrix.python }}
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
+          python -m pip install --upgrade pip setuptools wheel
           pip install flake8
           pip install -r requirements.txt
           pip install -r requirements-test.txt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@ Change Log
 ==========
 
 
-3.1.0
+4.0.0
 -----
 
 * Upgraded to Django 4.1.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@ Change Log
 ==========
 
 
+3.1.0
+-----
+
+* Upgraded to Django 4.1.
+* Dropped support for Django 2.2.
+* Dropped support for Python 3.6-3.7.
+* Added support for Python 3.10.
+
+
 3.0.0
 -----
 
@@ -14,6 +23,7 @@ Change Log
 * Renamed `level` feature to `levelFeature`.
 * Replaced Travis with GitHub Actions.
 * Added support for Python 3.9.
+
 
 2.0.0
 -----

--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ entered or an invalid level value) you may receive an HTTP 400 to indicate that 
 Requirements
 ------------
 
-* Django 2.2
-* Python 3.6-3.9
+* Django 4.1
+* Python 3.8-3.10
 * [edtf-validate](https://github.com/unt-libraries/edtf-validate) >= 1.1.0
 
 

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,3 +1,3 @@
-django~=2.2.17
+django~=4.1.2
 pytest
 pytest-django

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-django~=2.2.17
+django~=4.1.2
 git+https://github.com/unt-libraries/edtf-validate.git@master#egg=edtf-validate

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='django-edtf',
-    version='3.0.0',
+    version='3.1.0',
     description='A Django app for the validation of dates in the Extended Date Time Format.',
     long_description=('Please visit https://github.com/unt-libraries/django-edtf'
                       ' for the latest documentation.'),
@@ -16,10 +16,10 @@ setup(
     classifiers=[
         'Natural Language :: English',
         'Environment :: Web Environment',
-        'Framework :: Django :: 2.2',
+        'Framework :: Django :: 4.1',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.8'
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
     ]
 )

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='django-edtf',
-    version='3.1.0',
+    version='4.0.0',
     description='A Django app for the validation of dates in the Extended Date Time Format.',
     long_description=('Please visit https://github.com/unt-libraries/django-edtf'
                       ' for the latest documentation.'),

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -50,8 +50,6 @@ TIME_ZONE = 'UTC'
 
 USE_I18N = True
 
-USE_L10N = True
-
 USE_TZ = True
 
 STATIC_URL = '/static/'

--- a/tox.ini
+++ b/tox.ini
@@ -4,8 +4,8 @@ python_files = tests/tests.py
 
 [tox]
 envlist =
-    py{36, 37, 38, 39}-django22
-    py38-flake8
+    py{38, 39, 310}-django41
+    py39-flake8
 
 [flake8]
 max-line-length = 99
@@ -15,6 +15,6 @@ download = True
 deps = -rrequirements-test.txt
 commands = pytest
 
-[testenv:py38-flake8]
+[testenv:py39-flake8]
 deps=flake8
 commands = flake8 edtf tests setup.py


### PR DESCRIPTION
No major changes here, but because we do use `edtf-validate` I had to add `wheel` to the `install dependencies` step in the github actions yml. There was a deprecation warning for using `setup.py install`.